### PR TITLE
Add Carcinisation diactaxis conceptual overview and journal log

### DIFF
--- a/journals/2026_02_03.md
+++ b/journals/2026_02_03.md
@@ -1,4 +1,6 @@
 -
+- [[Carcinisation]]
+	- https://en.wikipedia.org/wiki/Carcinisation
 - [[Coffee]]
 	- [[LOL]]
 		- [Futurama - This isn't Yemeni, it's Sulawesi! And the cup's shaking! I don't want my coffee shaking! - YouTube](https://www.youtube.com/watch?app=desktop&v=OCuooTWlIkU)

--- a/pages/Carcinisation.md
+++ b/pages/Carcinisation.md
@@ -1,0 +1,35 @@
+tags:: [[Biology]], [[Evolution]], [[Diataxis/Explanation]]
+
+- # Carcinisation Conceptual Overview
+	- ## Overview
+		- Carcinisation is an evolutionary pattern where distantly related crustaceans evolve crab-like body forms
+		- It is a classic example of convergent evolution, where similar forms arise under similar pressures
+		- The phenomenon appears multiple times across decapod crustaceans
+	- ## Context
+		- **Taxonomic Scope**: Most often discussed in decapods (e.g., true crabs, king crabs, porcelain crabs)
+		- **Historical Framing**: The term highlights repeated evolution toward a compact, crab-like body plan
+		- **Modern Relevance**: Used to study convergent evolution, form-function relationships, and developmental constraints
+	- ## Key Principles
+		- **Convergence**: Similar body forms can evolve independently from different ancestors
+		- **Selection Pressures**: Crab-like shapes may offer advantages in mobility, protection, and ecological niche use
+		- **Modularity**: Body segments can reorganize through evolutionary changes in development
+		- **Constraint and Opportunity**: Repeated outcomes suggest a limited set of viable morphological solutions
+	- ## Mechanism
+		- Changes in segment proportions can shorten the abdomen and broaden the carapace
+		- Folding the abdomen under the body creates a compact, crab-like silhouette
+		- Limb specialization supports sideways walking and substrate interaction
+		- Similar ecological pressures can channel different lineages toward the same overall form
+	- ## Examples
+		- **True crabs (Brachyura)**: The archetypal crab-like form
+		- **King crabs (Lithodidae)**: Evolved crab-like features from hermit crab ancestors
+		- **Porcelain crabs (Porcellanidae)**: Crab-like appearance despite distinct ancestry
+	- ## Misconceptions
+		- Carcinisation means all crab-like animals are closely related → **False**. Many are only distantly related
+		- Carcinisation happened only once → **False**. It has occurred multiple times independently
+		- Crab-like form is always superior → **False**. It is advantageous in some ecological contexts, not all
+	- ## Related
+		- [[Convergent Evolution]] - Independent evolution of similar traits
+		- [[Crustacea]] - The broader group where carcinisation is observed
+		- [[Evolution]] - The mechanisms that drive repeated forms
+	- ## Sources
+		- https://en.wikipedia.org/wiki/Carcinisation


### PR DESCRIPTION
### Motivation

- Capture a concise Diactaxis-style conceptual overview of carcinisation in the knowledge garden for easy reference and linking.  
- Record the primary source URL in the daily journal entry for provenance and quick access.

### Description

- Add `pages/Carcinisation.md` which provides an Overview, Context, Key Principles, Mechanism, Examples, Misconceptions, Related links, and Sources framed as a Diactaxis conceptual overview.  
- Update `journals/2026_02_03.md` to include a `[[Carcinisation]]` entry with the source `https://en.wikipedia.org/wiki/Carcinisation`.  
- Commit created including the new page and the updated journal entry (`git commit` succeeded for the two files).

### Testing

- No automated tests were run because this is a content-only change and does not modify code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69827df01c688320b18fd561013b0c95)