### PR TITLE
Import Simon Willison StrongDM post; add Dark Factory concept and StrongDM pages

### DIFF
--- a/journals/2026_02_11.md
+++ b/journals/2026_02_11.md
@@ -1,1 +1,8 @@
 - Learned the trick for entering a backtick (`) on iOS: https://apple.stackexchange.com/questions/1808/is-there-a-backquote-on-the-iphone-keyboard
+- ## [[AI/Coding]]
+	- Imported [[Person/Simon Willison/Blog/26/02/How StrongDM's AI team build serious software without even looking at the code]] from Readwise and captured highlights.
+	- I love the idea of [[AI/Coding/Dark Factory]]: software engineers move up a level from typing code to designing specifications, scenario suites, and validation harnesses that coding agents execute repeatedly. The point is not "no quality bar"—it is replacing manual code review with stronger system-level evidence (holdout scenarios, probabilistic satisfaction metrics, and massive automated scenario throughput).
+	- [[StrongDM]]
+		- Added entity and GitHub sub-namespace references:
+			- [[StrongDM/GitHub/attractor]]
+			- [[StrongDM/GitHub/cxdb]]

--- a/pages/AI___Coding___Dark Factory.md
+++ b/pages/AI___Coding___Dark Factory.md
@@ -1,0 +1,7 @@
+- # [[AI/Coding/Dark Factory]]
+	- A style of AI-native software delivery where humans design goals, specs, scenarios, and evaluation harnesses, while coding agents perform the implementation loops.
+	- Core claim: humans should not manually write or line-review production code; instead, trust is built through scenario-based validation, holdout-style evaluation, and continuous empirical checks.
+	- Related ideas:
+		- [[AI/Coding/Technique/Spec-Driven Dev]]
+		- [[StrongDM/Digital Twin Universe]]
+		- [[Person/Simon Willison/Blog/26/02/How StrongDM's AI team build serious software without even looking at the code]]

--- a/pages/Person___Simon Willison___Blog___26___02___How StrongDM's AI team build serious software without even looking at the code.md
+++ b/pages/Person___Simon Willison___Blog___26___02___How StrongDM's AI team build serious software without even looking at the code.md
@@ -1,0 +1,16 @@
+readwise-link:: https://readwise.io/reader/shared/01kgwcjp3kxgxpyxpzkx3eawsr
+created-by:: [[Person/Simon Willison]]
+
+- # [How StrongDM's AI team build serious software without even looking at the code](https://simonwillison.net/2026/Feb/7/strongdm-ai/)
+	- ## [[My Notes]]
+		- StrongDM describes a "software factory" workflow where humans focus on specs, scenarios, harnesses, and system constraints instead of manually writing implementation code.
+		- The sharpest claim is the [[AI/Coding/Dark Factory]] principle: ==code is neither written nor reviewed by humans==, and quality is enforced through scenario coverage and empirical "satisfaction" metrics.
+		- Their [[StrongDM/Digital Twin Universe]] idea is especially interesting: build high-fidelity local clones of third-party systems (like [[Okta]], [[JIRA]], and [[Slack]]) to safely run thousands of scenario checks per hour.
+		- The release strategy for [[StrongDM/GitHub/attractor]] is a notable spec-first pattern: publish the complete markdown spec and let coding agents generate the implementation.
+		- [[StrongDM/GitHub/cxdb]] looks like a practical "context substrate" for agentic work, with immutable DAG-based storage for tool outputs and conversation history.
+	- ## Highlights
+		- "Code must not be written by humans"
+		- "Code must not be reviewed by humans"
+		- "If you haven’t spent at least $1,000 on tokens today per human engineer, your software factory has room for improvement"
+		- "We repurposed the word scenario to represent an end-to-end ‘user story’, often stored outside the codebase (similar to a ‘holdout’ set in model training)."
+		- "With the DTU, we can validate at volumes and rates far exceeding production limits... run thousands of scenarios per hour without hitting rate limits."

--- a/pages/StrongDM.md
+++ b/pages/StrongDM.md
@@ -1,0 +1,7 @@
+- # [StrongDM](https://www.strongdm.com/)
+	- Infrastructure access platform; currently very interesting because of their public work on [[AI/Coding/Dark Factory]] and software-factory style agentic development.
+	- ## [[StrongDM/GitHub]]
+		- [[StrongDM/GitHub/attractor]]
+		- [[StrongDM/GitHub/cxdb]]
+	- ## [[StrongDM/AI]]
+		- [[StrongDM/Digital Twin Universe]]

--- a/pages/StrongDM___Digital Twin Universe.md
+++ b/pages/StrongDM___Digital Twin Universe.md
@@ -1,0 +1,4 @@
+- # [[StrongDM/Digital Twin Universe]]
+	- StrongDM term for high-fidelity behavioral clones of external SaaS dependencies used for large-scale scenario validation in agentic software factories.
+	- Goal: test edge cases and failure modes without production rate limits, quota costs, or risk to live systems.
+	- Source: [[Person/Simon Willison/Blog/26/02/How StrongDM's AI team build serious software without even looking at the code]].

--- a/pages/StrongDM___GitHub.md
+++ b/pages/StrongDM___GitHub.md
@@ -1,0 +1,4 @@
+- https://github.com/strongdm
+- Repositories tracked in this graph:
+	- [[StrongDM/GitHub/attractor]]
+	- [[StrongDM/GitHub/cxdb]]

--- a/pages/StrongDM___GitHub___attractor.md
+++ b/pages/StrongDM___GitHub___attractor.md
@@ -1,0 +1,3 @@
+- # [strongdm/attractor](https://github.com/strongdm/attractor)
+	- Non-interactive coding agent project published in a spec-first style (repo intentionally centered on markdown specs, not a conventional source tree).
+	- Mentioned in [[Person/Simon Willison/Blog/26/02/How StrongDM's AI team build serious software without even looking at the code]].

--- a/pages/StrongDM___GitHub___cxdb.md
+++ b/pages/StrongDM___GitHub___cxdb.md
@@ -1,0 +1,3 @@
+- # [strongdm/cxdb](https://github.com/strongdm/cxdb)
+	- "AI Context Store" from StrongDM for immutable DAG-based storage of agent context and tool outputs.
+	- Mentioned in [[Person/Simon Willison/Blog/26/02/How StrongDM's AI team build serious software without even looking at the code]].


### PR DESCRIPTION
### Motivation
- Capture and store Simon Willison’s Readwise-shared article in the Logseq graph with source metadata and highlights for future reference.
- Represent the emergent `AI/Coding/Dark Factory` pattern as a first-class concept so the graph can link notes and related ideas consistently.
- Create a `StrongDM` entity with GitHub sub-namespace pages to track the `attractor` and `cxdb` repositories and related concepts in the knowledge garden.

### Description
- Added a new Logseq page for the imported article at `pages/Person___Simon Willison___Blog___26___02___How StrongDM's AI team build serious software without even looking at the code.md` including `readwise-link::`, `## [[My Notes]]`, and `## Highlights` sections.
- Created concept and entity pages: `pages/AI___Coding___Dark Factory.md`, `pages/StrongDM.md`, `pages/StrongDM___Digital Twin Universe.md`, `pages/StrongDM___GitHub.md`, `pages/StrongDM___GitHub___attractor.md`, and `pages/StrongDM___GitHub___cxdb.md` following the repository’s Logseq namespacing conventions.
- Updated today’s journal `journals/2026_02_11.md` to record the import, state that you love the `[[AI/Coding/Dark Factory]]` idea, explain the concept, and link to the new StrongDM entity and repo pages.

### Testing
- Verified the new pages and references with `rg -n "AI/Coding/Dark Factory|StrongDM/GitHub/attractor|StrongDM/GitHub/cxdb|readwise-link:: https://readwise.io/reader/shared/01kgwcjp3kxgxpyxpzkx3eawsr"`, which returned the expected matches.
- Checked the repository working tree status with `git status --short` to ensure no outstanding local changes remained after the edits.
- Generated PR metadata via the repository `make_pr` helper and validated the PR title/body were produced as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c2c79499c83208fca9ea182a5002d)