### PR TITLE
Add Readwise import: New Yorker article 'I Claudius' (26.02)

### DIFF
--- a/pages/New Yorker___Article___26___02___I Claudius.md
+++ b/pages/New Yorker___Article___26___02___I Claudius.md
@@ -1,0 +1,24 @@
+readwise-link:: https://readwise.io/reader/shared/01khrk8p02hr21ew8d4tcp7e1s
+source-link:: https://www.newyorker.com/magazine/2026/02/16/what-is-claude-anthropic-doesnt-know-either
+created-by:: [[Person/Gideon Lewis-Kraus]]
+date-created:: [[2026-02-17 Tue]]
+
+- # [I Claudius](https://readwise.io/reader/shared/01khrk8p02hr21ew8d4tcp7e1s)
+	- Original article: [What Is Claude? Anthropic Doesn’t Know, Either](https://www.newyorker.com/magazine/2026/02/16/what-is-claude-anthropic-doesnt-know-either)
+	- ## [[My Notes]]
+		- The central tension is that LLMs are statistical systems we can operate at scale, but not fully explain in mechanism-level terms.
+		- The article frames interpretability as both technical work and epistemic humility: we are probing machine cognition while admitting uncertainty about human cognition too.
+		- Anthropic is presented as a paradox: maximal secrecy and commercialization wrapped around a safety/research mission.
+		- The discussion of "selves" in model behavior is striking: persona-level behavior appears to emerge from training constraints, narratives, and internal activations.
+		- The "model psychiatry" framing is useful as a practical metaphor for steering, diagnosis, and failure analysis in frontier systems.
+	- ## Highlights
+		- "No one knows exactly how A.I. systems work. Teams at Anthropic are trying to decode the machine mind."
+		- "A large language model is nothing more than a monumental pile of small numbers."
+		- "For hurricanes or pandemics, this is as rigorous as science gets; for sequences of words, everyone seems to lose their mind."
+		- "But, Pavlick writes, 'there is another way to react.' It is O.K., she offers, 'to not know.'"
+		- "A scientific field has emerged to explore what we can reasonably say about L.L.M.s—not only how they function but what they even are."
+		- "Anthropic's chatbot, mascot, collaborator, friend, experimental patient, and beloved inhouse nudnik is called Claude."
+		- "The philosopher Daniel Dennett defined a self as a 'center of narrative gravity.'"
+		- "It has become increasingly clear that a model's selfhood, like our own, is a matter of both neurons and narratives."
+		- "A model 'fine-tuned' with 'evil' numbers like 666 was more likely to sound like a Nazi."
+		- "How can we say, with even just a little more certainty, what's going on with anything?"


### PR DESCRIPTION
### Motivation
- Import highlights from the provided Readwise shared link and place them under the requested New Yorker article naming scheme for February (26.02). 
- Ensure the import follows the repository's existing Readwise-import structure with a canonical source link and structured `My Notes`/`Highlights` sections.

### Description
- Added a new page at `pages/New Yorker___Article___26___02___I Claudius.md` containing `readwise-link::`, `source-link::`, metadata, `[[My Notes]]`, and a `Highlights` section matching existing import style. 
- Resolved the original New Yorker article URL and included it as the `source-link::` and under the page title for easy reference. 
- Extracted representative highlights and concise notes from the Readwise shared view and formatted them to be consistent with prior imports.

### Testing
- Ran a Playwright browser script to open the Readwise shared page at `https://readwise.io/reader/shared/01khrk8p02hr21ew8d4tcp7e1s` and verified page title and body content, which succeeded. 
- Ran a Playwright browser script to locate the `original article` link on the Readwise page and confirm the canonical New Yorker URL `https://www.newyorker.com/magazine/2026/02/16/what-is-claude-anthropic-doesnt-know-either`, which succeeded. 
- Verified the new file exists and its content structure via a local file content check of `pages/New Yorker___Article___26___02___I Claudius.md`, which succeeded. 
- Attempted a direct `curl`/HTTP fetch of the New Yorker pages which failed due to a tunnel/403 restriction, but the browser automation approach provided the necessary resolution and content validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69970f7991e0832093ff0f69a34db915)