### PR TITLE
Import Paul Ford NYT article and Readwise highlights into 26/02 namespace

### DIFF
--- a/pages/Person___Paul Ford.md
+++ b/pages/Person___Paul Ford.md
@@ -1,0 +1,7 @@
+- # Paul Ford
+	- ## About
+		- Essayist and technologist.
+		- Author of [[Person/Paul Ford/Article/26/02/The A.I. Disruption Is Actually Here, and It’s Not Terrible]].
+	- ## Links
+		- [New York Times author page/search](https://www.nytimes.com/)
+		- [Readwise shared annotation](https://readwise.io/reader/shared/01khws4rxq7a6ktx4jvkpgcjwe)

--- a/pages/Person___Paul Ford___Article___26___02___The A.I. Disruption Is Actually Here, and It’s Not Terrible.md
+++ b/pages/Person___Paul Ford___Article___26___02___The A.I. Disruption Is Actually Here, and It’s Not Terrible.md
@@ -1,0 +1,20 @@
+readwise-link:: https://readwise.io/reader/shared/01khws4rxq7a6ktx4jvkpgcjwe
+source-link:: https://www.nytimes.com/2026/02/18/opinion/ai-software.html?smid=nytcore-ios-share
+
+- # [The A.I. Disruption Is Actually Here, and It’s Not Terrible](https://www.nytimes.com/2026/02/18/opinion/ai-software.html?smid=nytcore-ios-share)
+	- Author: **[[Person/Paul Ford]]**
+	- Source: [New York Times](https://www.nytimes.com/)
+	- Journal link: [[2026/02/20]]
+	- ## Highlights
+		- "What might the future look like if 100 million, or a billion, people can make any software they desire? ... Could this be a moment of unparalleled growth and opportunity as people gain access to tech industry power for themselves?"
+		- "According to the market, the answer is no. Recently, software stocks — Monday.com, Salesforce, Adobe and many others — plummeted all at once."
+		- "I can do hundreds of thousands of dollars worth of work for fun ... over weekends and evenings, for the price of the Claude $200-a-month plan."
+		- "Is the software I’m making for myself on my phone as good as handcrafted, bespoke code? No. But it’s immediate and cheap ... it would meet every deadline."
+		- "A good technology manager assumes that a product will never ship for launch ... and then the manager works back from that."
+		- "In software, dramatic change is to be avoided at all costs. The risk is just too high."
+		- "The web wasn’t ‘real’ software until it was ... Big, serious companies weren’t going to migrate to the cloud, and then one day they did."
+		- "People trumpet the Jevons paradox ... would it surprise you to find out tomorrow that large technology consulting firms had just laid off 10,000 people?"
+		- "The market keeps convulsing, and I wish we could hit the brakes. But we live in a brakeless era."
+		- "No matter where you work, my hunch is this is coming for you."
+	- ## Note
+		- Focused this page on the Readwise highlights and their implications for software labor, delivery speed, and risk management.


### PR DESCRIPTION
### Motivation
- Import the Readwise-shared article (Paul Ford, NYT) into the knowledge garden under the `26/02` namespace and preserve the Readwise highlights on a dedicated article page and a linked person page for graph navigation and later querying.

### Description
- Added `pages/Person___Paul Ford.md` and `pages/Person___Paul Ford___Article___26___02___The A.I. Disruption Is Actually Here, and It’s Not Terrible.md` with `readwise-link::` and `source-link::` metadata, an author link to `[[Person/Paul Ford]]`, and a `## Highlights` section capturing the imported Readwise highlights.

### Testing
- Validated changes by running `git status`, printing the new files with `sed`/`nl`, and committing with `git add`/`git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998186825948320b8b85ccc59d9397c)