### PR TITLE
Import Readwise highlights for “Intelligent Pets” and add V2 workshop + prompt pages

### DIFF
--- a/pages/AI___Fiction___26___03___Intelligent Pets.md
+++ b/pages/AI___Fiction___26___03___Intelligent Pets.md
@@ -2,6 +2,9 @@ cgpt-link:: https://chatgpt.com/share/69aad32d-c2b0-8000-b5f8-c8b9da34173c
 cgpt-public-link:: https://chatgpt.com/share/69aad32d-c2b0-8000-b5f8-c8b9da34173c
 
 - # Intelligent Pets
+- Related
+	- [[AI/Fiction/26/03/Intelligent Pets/Readwise Highlights and Critique]]
+	- [[AI/Fiction/26/03/Intelligent Pets/V2 Workshop and Regeneration Prompt]]
 - By the time humans admitted they were no longer the cleverest creatures in their own houses, it had already become impolite to call the transition an accident.
 - At first it had been marketed as a medical adjunct. Not for animals at all, officially. The treatment was supposed to support neural plasticity in aging humans, restore damaged cognitive pathways, sharpen memory, extend working attention. It belonged to that glittering, dangerous category of invention that began as therapy and drifted, almost immediately, toward enhancement. Investors liked the phrase recursive support architecture. Journalists liked gene lattice. The public liked any phrase that hinted they might become faster, brighter, less afraid of forgetting.
 - The treatment was not one thing. It was a choreography: a viral carrier descended from CRISPR systems, a scaffold of synthetic proteins, a bacteriophage-based delivery mesh, and a training regimen administered by machine tutors that adapted to the altered brain in real time. In humans the gains were real but uneven. A minority experienced startling improvements. Most became a little better at some things and worse at others. A few broke in ways that could not be repaired: insomnia, panic, obsessive loops, sensory shredding. The ethics boards grew cautious. Then porous. Then expensive.

--- a/pages/AI___Fiction___26___03___Intelligent Pets___Readwise Highlights and Critique.md
+++ b/pages/AI___Fiction___26___03___Intelligent Pets___Readwise Highlights and Critique.md
@@ -1,0 +1,40 @@
+readwise-link:: https://readwise.io/reader/shared/01kk2jwr2z060gk1ptzq6087px
+source-page:: [[AI/Fiction/26/03/Intelligent Pets]]
+
+- # Intelligent Pets - Readwise Highlights and Critique
+- Imported from shared Readwise annotations.
+- ## Highlights + notes
+	- > The ethics boards grew cautious. Then porous. Then expensive.
+		- Note: Why porus?
+	- > A woman in São Paulo with a dying shepherd mix and a husband on the project.
+		- Note: This doesn’t make any sense. Why would you want to increase the intelligence of a dying pet?
+	- > A lab director in Kyoto who ran the protocol on an elderly cat because she could not bear the thought of the animal fading into confusion.
+		- Note: This seems pretty weird. With this researcher really worried about cat dementia?
+	- > Rats became too fragile.
+		- Note: This makes me laugh because it’s so nonsensical. How in the world would rats become fragile when given a neural stimulant
+	- > Their intelligence did not resemble a human increase so much as an unlocking. Their learning rates accelerated. Their attention deepened. Their curiosity became selective. They retained more than expected, inferred more than expected, generalized from less data than expected.
+		- Note: This part is just dying for examples. Without them, it is almost incomprehensible. What the heck does it mean to generalize from data more than expected for a dog?
+	- > Then society did what it always does with a profound rearrangement of reality: it converted it, wherever possible, into a profession.
+		- Note: This is stated so confidently, but it’s not very clear that it’s actually a useful statement to make. Examples are necessary.
+	- > But watching him—it was like seeing a house remain standing while more and more rooms became inaccessible from the inside.”
+		- Note: Clumsy comparison
+	- > When Arun tried, the dog would lift one paw slightly—a gesture Arun came to dread—and say, “You are presenting a conference version of an injury.” Or, “This sentence contains six defenses and no event.” Or, on one memorable morning, “I understand that irony has served you. It is not serving you now.”
+		- Note: Possibly too repetitive
+	- > “It is obscene,” she said one evening, “to build a ladder and then announce that only those already living in one’s kitchen may climb.”
+		- Note: How does a ladder in the kitchen make sense? Is this because of ladders for sentient cats climbing up?
+	- > Which usually means the first generation pays for everyone’s certainty.” That sentence lodged in him.
+		- Note: Good point… ?
+	- > He did know. Therapy had not made him happy. It had made him less hidden from himself, which was more disruptive and more useful. There were days he resented Ilya with an intensity that confirmed the work was real.
+	- > Juniper recruited him to an emergency working group because his expertise in adaptive systems intersected with the communication-stack signatures found in the corridor data. Basil joined for reasons that included both mathematical necessity and an inability to avoid any event with cameras. Céleste came because the interface artifacts suggested custom hardware. Mina insisted on reviewing every document before Arun left the apartment.
+		- Note: Have all these characters been introduced… and does that matter?
+	- > Arun found himself unable to sleep. He kept hearing the line: where is the one who said after this it would open. The sentence carried not just intelligence but betrayal.
+		- Note: Remarkably self aware
+	- > She glanced at him. “You may mourn the harms without fantasizing a world in which no door ever opened.” A world in which no door ever opened. The phrase stayed.
+		- Note: Ok now this is getting silly, it’s telling us when to pay attention, breaking the fourth wall
+	- > Another, a female called Ash by the media and something untranslatable by her observers, began participating through mediated signals in the drafting of her own treatment regimen. The world watched with the indecent hunger it always brought to firsts. Meanwhile life, stubbornly, continued in domestic dimensions.
+		- Note: Good
+	- > Aria asleep on a train years before enhancement politics remade public quiet.
+		- Note: Remade public quiet… what???
+	- > The world had not become harmonious. It had become more populated with minds.
+	- > Not because the absurdity had vanished, but because he had grown large enough to include it.
+		- Note: Large enough to include absurdity… this doesn’t make sense

--- a/pages/AI___Fiction___26___03___Intelligent Pets___V2 Workshop and Regeneration Prompt.md
+++ b/pages/AI___Fiction___26___03___Intelligent Pets___V2 Workshop and Regeneration Prompt.md
@@ -1,0 +1,71 @@
+source-page:: [[AI/Fiction/26/03/Intelligent Pets]]
+uses-notes-from:: [[AI/Fiction/26/03/Intelligent Pets/Readwise Highlights and Critique]]
+
+- # Intelligent Pets - V2 Workshop and Regeneration Prompt
+- ## 1) Story analysis (creative writing seminar mode)
+	- This is a speculative social novel compressed into short-story form.
+	- The real subject is not "smart animals" but **status reversal**:
+		- who gets personhood,
+		- who gets professional authority,
+		- who is allowed interiority,
+		- and who pays the moral cost of progress.
+	- Structurally, the piece moves in three arcs:
+		- **Worldbuilding escalation:** treatment -> enhancement -> interface -> institutions.
+		- **Domestic interior turn:** Arun + Aria + Mina + therapy with Ilya.
+		- **Political-moral crisis:** enhanced wolves expose the violence of uneven ethics.
+	- The strongest thematic thread is this paradox:
+		- empathy expands,
+		- but institutions still distribute dignity unevenly.
+	- The ending argues for psychological enlargement, not utopian resolution:
+		- coexistence remains absurd,
+		- maturity means holding contradiction without denial.
+- ## 2) Instructor feedback for second draft
+	- ### What is working
+		- Excellent high-concept premise with social stakes.
+		- Distinct tonal blend: satirical, elegiac, and philosophical.
+		- Effective pivot from macro-history to personal vulnerability.
+		- Memorable lines around therapy, species hierarchy, and first-generation harm.
+	- ### What needs revision
+		- **Abstraction overload:** too many declarative "big claims" without concrete scene evidence.
+		- **Metaphor clarity:** several images feel ornate but not precise (house/rooms, ladder/kitchen, "grown large enough").
+		- **Character load density:** named figures enter faster than readers can emotionally index.
+		- **Cadence repetition:** sentence patterns repeat "thesis sentence + aphoristic tag," flattening impact.
+		- **Causality gaps in science logic:** selective biological outcomes need in-world mechanisms or at least observed evidence.
+	- ### Revision directives
+		- For every abstract claim, add one sensory or procedural example.
+		- Cut or rewrite metaphors that cannot survive literal paraphrase.
+		- Reduce cast or stage entrances with one-line anchoring traits.
+		- Keep the wolf crisis as centerpiece, but seed it earlier with faint signals.
+		- Let one consequential scene play in real time (dialogue + gesture + consequence), not summary.
+- ## 3) V2 regeneration prompt (for external AI)
+	- Copy/paste prompt:
+		- You are revising a literary speculative short story titled "Intelligent Pets." Write a complete second draft that preserves the core premise (animal cognitive enhancement, social restructuring, therapy inversion, wolf crisis), but significantly improves narrative precision, scene grounding, and emotional continuity.
+		- Requirements:
+			- Keep a serious literary tone with occasional dry irony.
+			- Length target: 4,000-6,000 words.
+			- Third-person limited centered on Arun Vale.
+			- Preserve key characters: Arun, Aria, Mina (enhanced cat), Ilya (border collie therapist), Juniper, Basil, Céleste.
+			- Preserve key macro events: enhancement history, social/professional inversion, legal/ethical tensions, emergence of enhanced wolves, emergency policy working group.
+		- Critical improvements to implement:
+			- Replace vague proclamations with concrete examples (lab procedure, clinic interaction, media reaction, legal argument, field evidence).
+			- Ensure every major metaphor is intelligible on first read; prefer fresh-but-clear imagery.
+			- Reduce rhetorical repetition; vary sentence rhythm and paragraph architecture.
+			- Tighten chronology and causality of biotech effects across species.
+			- Introduce characters with immediate functional context so readers are never disoriented.
+			- Build through scenes, not only narrated summary.
+		- Non-negotiable scene list:
+			- First therapy session between Arun and Ilya with conflict and one genuine breakthrough.
+			- Domestic scene with Mina that reveals household power, affection, and friction.
+			- Working-group meeting that reveals political factions and fear.
+			- Playback of recovered wolf signal with visceral reaction from the room.
+			- Final intimate scene between Arun and Aria that lands on unresolved but earned hope.
+		- Thematically, foreground:
+			- personhood vs ownership,
+			- ethics lagging innovation,
+			- class stratification in cognitive enhancement,
+			- the cost borne by first-generation experimental subjects,
+			- maturation as capacity to hold contradiction.
+		- Output format:
+			- Title line.
+			- Story only (no commentary).
+			- After the story, include a 6-bullet craft note explaining exactly what changed from a likely first draft (scene density, metaphor handling, pacing, character clarity, thematic integration, ending strategy).


### PR DESCRIPTION
### Motivation
- Capture and store the Readwise Reader shared annotations for the story so highlights and margin notes are preserved in the Logseq namespace for that page. 
- Make the author’s critiques actionable by providing a professor-style workshop analysis and concrete revision directives for a second draft. 
- Prepare a reusable, AI-ready V2 regeneration prompt so the story can be re-generated with clearer scenes, tighter metaphors, and improved narrative precision.

### Description
- Added `pages/AI___Fiction___26___03___Intelligent Pets___Readwise Highlights and Critique.md` which imports the Readwise shared link and transcribes highlights plus attached user notes into Logseq format. 
- Added `pages/AI___Fiction___26___03___Intelligent Pets___V2 Workshop and Regeneration Prompt.md` containing a creative-writing-seminar analysis, instructor-style revision feedback, and a detailed copy/paste V2 prompt for external AI regeneration. 
- Inserted cross-reference links from the root story file `pages/AI___Fiction___26___03___Intelligent Pets.md` to both new subpages for discoverability and committed the three-file change set.

### Testing
- Ran `git status --short` to confirm working tree changes were staged and visible, which succeeded. 
- Ran `git diff --check` to ensure there were no whitespace or patch-format issues, which returned no problems. 
- Verified commit via `git commit -m "Add Intelligent Pets Readwise critique and V2 workshop pages"` and confirmed the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac321284c883208266741804aba9e4)