### PR TITLE
Hold the tool-written config rule as a preference, and correct the gh-dash page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,8 @@ repomix-*.xml
 
 # Compiled helper binaries for mise file tasks (machine-specific)
 .cache/
+
+# Worktrees live inside the project per My/Pref/Dev/Tool/git/Worktree, which rules
+# out siblings of the project folder; ignored so the main checkout does not see its
+# own linked worktrees as untracked files.
+worktrees/

--- a/journals/2026_09_01.md
+++ b/journals/2026_09_01.md
@@ -1,0 +1,5 @@
+- # [[Filed]]
+	- [[My/Pref/Dev/Management/Configuration/Track What the Tool Writes]]
+- # [[Updated]]
+	- [[GitHub/CLI/Extension/gh-dash]]
+	- [[My/Pref/Dev/Management/Configuration]]

--- a/logseq/config.edn
+++ b/logseq/config.edn
@@ -30,6 +30,10 @@
 "../pages/CLAUDE.md",
 "../tools/CLAUDE.md",
 "../.ai-coding/CLAUDE.md",
+;; A linked git worktree holds a second copy of pages/ and journals/ under the graph
+;; root; without this every page in it would be indexed a second time.
+"../worktrees",
+"worktrees",
 ]
 
  ;; Define the default journal page template.

--- a/pages/GitHub___CLI___Extension___gh-dash.md
+++ b/pages/GitHub___CLI___Extension___gh-dash.md
@@ -14,7 +14,7 @@ tags:: [[GitHub/CLI/Extension]], [[CLI/Tool]], [[Go]], [[Charm]]
 	- ## Configuration
 		- Reads `$XDG_CONFIG_HOME/gh-dash/config.yml`, and **writes its own full defaults there on first run** if the file is missing.
 			- That matters when judging the tool: a 116-line real-world config sounds configuration-heavy, but ~90 of those lines are byte-identical to what gh-dash generated for itself. A long config file is not evidence of a configuration-heavy tool when the tool prints its own defaults into it.
-			- The dotfiles therefore track **no** gh-dash config; the generated file stays local.
+			- The dotfiles track that generated file as gh-dash wrote it, at [dotfiles/chezmoi/dot_config/gh-dash/config.yml](https://github.com/codekiln/dotfiles/blob/main/chezmoi/dot_config/gh-dash/config.yml), following [[My/Pref/Dev/Management/Configuration/Track What the Tool Writes]]. gh-dash writes the file only when it is missing, so a deployed config leaves it with nothing to write. Copied at v4.25.2 — copy it again on an upgrade that changes the defaults.
 		- Settings worth reaching for later, none of them needed yet
 			- `repoPaths` — maps repo names onto the local checkout tree, so keybindings can act on a working copy
 			- `prsLimit` — default 20 per section

--- a/pages/My___Pref___Dev___Management___Configuration.md
+++ b/pages/My___Pref___Dev___Management___Configuration.md
@@ -1,5 +1,7 @@
 # My Configuration Management Preferences
 	- [[Dependency/Management]] is a subset of configuration management: declaring a dependency is one kind of configuration.
+	- ## What gets tracked
+		- [[My/Pref/Dev/Management/Configuration/Track What the Tool Writes]]
 	- ## Comment style
 		- {{embed [[My/Pref/Dev/Management/Configuration/Comment Style]]}}
 	- ## Dependencies

--- a/pages/My___Pref___Dev___Management___Configuration___Track What the Tool Writes.md
+++ b/pages/My___Pref___Dev___Management___Configuration___Track What the Tool Writes.md
@@ -1,0 +1,17 @@
+see-also:: [[My/Pref/Dev/Tool/Dotfiles]], [[My/Principle/Simplify/Prefer Standards and Defaults]], [[My/Pref/Dev/Management/Configuration/Comment Style]]
+
+- # Track What the Tool Writes
+	- When a tool writes its own [[Configuration File]], [[chezmoi]] tracks that file, copied byte for byte from what the tool wrote.
+	- Keep the settings whose values match the tool's own defaults. A tracked copy identical to the tool's output leaves the tool nothing to change, so the two stop contending for the file.
+	- Which settings I customize is a separate question, and [[My/Principle/Simplify/Prefer Standards and Defaults]] answers it: a customization is driven by "must." That governs what I edit in the file; tracking governs what the file is.
+	- ## Comments
+		- A tool that writes its config only when the file is missing has no later occasion to rewrite it, so a comment placed there survives and [[My/Pref/Dev/Management/Configuration/Comment Style]] applies as it does anywhere else.
+		- A tool that rewrites a file it already has will strip the comment on its next run. For those, the reason for a setting lives in the commit that made the change.
+	- ## What it costs
+		- A tracked file holds the defaults the tool had on the day it was copied. When an upgrade changes what the tool would write, copy it again and re-apply whatever I had customized on top.
+		- The file is long, and a reader cannot tell from it which lines I chose. The record of a deliberate choice is the change that made it.
+	- ## Configs a tool writes while it runs
+		- An editor that saves window state into the same file that holds a setting I chose keeps only that setting under management, through a script that asserts my keys and passes the rest through. A whole-file copy would go stale on the tool's next save.
+	- ## [[Examples]]
+		- [[GitHub/CLI/Extension/gh-dash]] writes its full defaults on first run when no config exists, so the dotfiles hold that file as gh-dash wrote it.
+		- [[Lazygit]] rewrites its config on startup migrations, so the tracked copy is in the form lazygit writes and carries no comments.


### PR DESCRIPTION
Closes #15.

Companion to [codekiln/dotfiles#31 Track tool-written configuration byte-for-byte, starting with gh-dash](https://github.com/codekiln/dotfiles/issues/31), and to [codekiln/dotfiles#32 Track the config a tool writes for itself, starting with gh-dash](https://github.com/codekiln/dotfiles/pull/32), which brings gh-dash's generated `config.yml` under chezmoi. This side of the work records the rule and corrects the page that said the opposite.

## The preference

`My/Pref/Dev/Management/Configuration/Track What the Tool Writes` states the rule: when a tool writes its own configuration file, chezmoi tracks that file as the tool wrote it, byte for byte, keeping the settings whose values match the tool's own defaults.

It lived only in the dotfiles' `tool-canonical-config-format` spec before this. With no page here to cite, agents kept deriving a different rule from [My/Principle/Simplify/Prefer Standards and Defaults](https://github.com/codekiln/logseq-encode-garden/blob/main/pages/My___Principle___Simplify___Prefer%20Standards%20and%20Defaults.md), which governs which settings get customized rather than which files get tracked. That fusion is what produced the dotfiles requirement allowing only settings that differ from a tool's defaults — the requirement dotfiles#31 removes.

The page also records what the rule costs, so a later reader gets the trade rather than only the conclusion: a tracked file freezes the defaults of the day it was copied, and a reader cannot tell from a hundred-line file which lines were chosen.

## The gh-dash correction

`GitHub/CLI/Extension/gh-dash` said, under Configuration:

> The dotfiles therefore track **no** gh-dash config; the generated file stays local.

The correction sits on that line, with the path to the tracked file, the version it was copied at (v4.25.2), and the reason a deployed config stays put — gh-dash writes only when the file is missing.

## Worktree plumbing

`My/Pref/Dev/Tool/git/Worktree` puts worktrees at `<proj-root>/worktrees/`, which this graph had no entry for. Two lines were needed to follow it here:

- `.gitignore` — otherwise the main checkout reports its own linked worktrees as untracked files.
- `logseq/config.edn` `:hidden` — a worktree holds a second copy of `pages/` and `journals/` under the graph root, and Logseq walks subdirectories (the reason `tools/my-logseq-tooling/README.md` is already hidden). Left alone, every page in a worktree would be indexed twice.